### PR TITLE
move over the dependencies class

### DIFF
--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -34,8 +34,22 @@ void registerPackage(AtomPackage package) {
 
   final JsObject exports = context['module']['exports'];
 
-  exports['activate'] = _package.activate;
-  exports['deactivate'] = _package.deactivate;
+  exports['activate'] = ([state]) {
+    try {
+      _package.activate(state);
+    } catch (e, st) {
+      print('${e}');
+      print('${st}');
+    }
+  };
+  exports['deactivate'] = () {
+    try {
+      _package.deactivate();
+    } catch (e, st) {
+      print('${e}');
+      print('${st}');
+    }
+  };
   exports['config'] = jsify(_package.config());
   exports['serialize'] = _package.serialize;
 

--- a/lib/utils/dependencies.dart
+++ b/lib/utils/dependencies.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2016, Devon Carew. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+/// A simple dependency manager.
+library atom.dependencies;
+
+import 'dart:async';
+
+Dependencies get deps => Dependencies.instance;
+
+/**
+ * A simple dependency manager. This class manages a collection of singletons.
+ * You can create separate `Dependency` instances to manage separate sets of
+ * collections (for instance, one for testing). Or, you can use the single
+ * [dependency] instance defined in this library to set up all the singletons
+ * for your application.
+ *
+ *     Dependencies dependencies = new Dependencies();
+ *     dependencies.setDependency(CatManager, catManager);
+ *     dependencies.setDependency(DogManager, dogs);
+ *
+ *     ...
+ *
+ *     CatManager cats = dependencies[CatManager];
+ *     cats.corale();
+ *
+ * When you want to set up a new series of services, for doing something like
+ * executing tests with mocked out providers, you can use [runInZone]. So:
+ *
+ *     Dependencies dependencies = new Dependencies();
+ *     dependencies.setDependency(CatManager, new MockCatManager());
+ *     dependencies.setDependency(DogManager, new MockDogManager());
+ *     dependencies.runInZone(executeTests);
+ *
+ * It will execute the method [executeTests] in a new Zone. Any queries to
+ * [Dependencies.instance] will return the new dependencies set up for that
+ * zone.
+ */
+class Dependencies {
+  static Dependencies _global;
+
+  static setGlobalInstance(Dependencies deps) {
+    _global = deps;
+  }
+
+  /**
+   * Get the current logical instance. This is the instance associated with the
+   * current Zone, parent Zones, or the global instance.
+   */
+  static Dependencies get instance {
+    Dependencies deps = Zone.current['dependencies'];
+    return deps != null ? deps : _global;
+  }
+
+  Map<Type, dynamic> _instances = {};
+
+  Dependencies();
+
+  Dependencies get parent => _calcParent(Zone.current);
+
+  dynamic getDependency(Type type) {
+    if (_instances.containsKey(type)) {
+      return _instances[type];
+    }
+
+    Dependencies parent = _calcParent(Zone.current);
+    return parent != null ? parent.getDependency(type) : null;
+  }
+
+  void setDependency(Type type, dynamic instance) {
+    _instances[type] = instance;
+  }
+
+  dynamic operator[](Type type) => getDependency(type);
+
+  void operator[]=(Type type, dynamic instance) => setDependency(type, instance);
+
+  /**
+   * Return the [Type]s defined in this immediate [Dependencies] instance.
+   */
+  Iterable<Type> get types => _instances.keys;
+
+  /**
+   * Execute the given function in a new Zone. That zone is populated with the
+   * dependencies of this object. Any requests for dependencies are first
+   * satisfied with thie [Dependencies] object, and then delegate up to
+   * [Dependencies] for parent Zones.
+   */
+  void runInZone(Function function) {
+    Zone zone = Zone.current.fork(zoneValues: {'dependencies': this});
+    zone.run(function);
+  }
+
+  /**
+   * Determine the [Dependencies] instance that is the logical parent of the
+   * [Dependencies] for the given [Zone].
+   */
+  Dependencies _calcParent(Zone zone) {
+    if (this == _global) return null;
+
+    Zone parentZone = zone.parent;
+    if (parentZone == null) return _global;
+
+    Dependencies deps = parentZone['dependencies'];
+    if (deps == this) {
+      return _calcParent(parentZone);
+    } else {
+      return deps != null ? deps : _global;
+    }
+  }
+}

--- a/lib/utils/disposable.dart
+++ b/lib/utils/disposable.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, Devon Carew. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:logging/logging.dart';
 
 final Logger _logger = new Logger('disposable');
@@ -37,4 +39,41 @@ class Disposables implements Disposable {
 
     _disposables.clear();
   }
+}
+
+class StreamSubscriptions implements Disposable {
+  final bool catchExceptions;
+
+  List<StreamSubscription> _subscriptions = [];
+
+  StreamSubscriptions({this.catchExceptions});
+
+  void add(StreamSubscription subscription) => _subscriptions.add(subscription);
+
+  bool remove(StreamSubscription subscription) =>
+      _subscriptions.remove(subscription);
+
+  void cancel() {
+    for (StreamSubscription subscription in _subscriptions) {
+      if (catchExceptions) {
+        try {
+          subscription.cancel();
+        } catch (e, st) {
+          _logger.severe('exception during subscription cancel', e, st);
+        }
+      } else {
+        subscription.cancel();
+      }
+    }
+
+    _subscriptions.clear();
+  }
+
+  void dispose() => cancel();
+}
+
+class DisposeableSubscription implements Disposable {
+  final StreamSubscription sub;
+  DisposeableSubscription(this.sub);
+  void dispose() { sub.cancel(); }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
 
 dev_dependencies:
   grinder: ^0.8.0+1
+  test: ^0.12.0
 
 environment:
   sdk: '>=1.0.0 <2.0.0'

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2015, Devon Carew. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+import 'dependencies_test.dart' as dependencies_test;
+
+main() {
+  dependencies_test.defineTests();
+}

--- a/test/dependencies_test.dart
+++ b/test/dependencies_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2015, Devon Carew. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+library atom.dependencies_test;
+
+import 'package:atom/utils/dependencies.dart';
+import 'package:test/test.dart';
+
+main() => defineTests();
+
+defineTests() {
+  group('dependencies', () {
+    test('retrieve dependency', () {
+      Dependencies dependency = new Dependencies();
+      expect(dependency[String], isNull);
+      dependency[String] = 'foo';
+      expect(dependency[String], isNotNull);
+      expect(dependency[String], 'foo');
+    });
+
+    test('runInZone', () {
+      expect(Dependencies.instance, isNull);
+      Dependencies dependency = new Dependencies();
+      expect(Dependencies.instance, isNull);
+      dependency[String] = 'foo';
+      dependency.runInZone(() {
+        expect(Dependencies.instance, isNotNull);
+        expect(dependency[String], 'foo');
+      });
+      expect(Dependencies.instance, isNull);
+    });
+  });
+}


### PR DESCRIPTION
- catch and log any exceptions from plugin activation or decativation
- move other the utility `StreamSubscriptions` class
- move over the `dependencies.dart` library

@danrubel 
