### PR TITLE
join for file paths

### DIFF
--- a/lib/node/fs.dart
+++ b/lib/node/fs.dart
@@ -6,11 +6,24 @@ library node.fs;
 
 import '../src/js.dart';
 import 'node.dart';
+import 'process.dart';
 
 final FS fs = new FS._();
 
 class FS extends ProxyHolder {
   FS._() : super(require('fs'));
+
+  final String separator = isWindows ? r'\' : '/';
+
+  String join(dir, String arg1, [String arg2, String arg3]) {
+    //if (dir is Directory) dir = dir.path;
+    String path = '${dir}${separator}${arg1}';
+    if (arg2 != null) {
+      path = '${path}${separator}${arg2}';
+      if (arg3 != null) path = '${path}${separator}${arg3}';
+    }
+    return path;
+  }
 
   /// Relative path entries are removed and symlinks are resolved to their final
   /// destination.


### PR DESCRIPTION
@devoncarew I need a join(...) method for file paths.
Is this a reasonable place, or make a 'path' library similar to package:path (can't use it), or ... ?
