### PR TITLE
Support customevent

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, Devon Carew. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+// TODO: This is a workaround for the fact that typed arrays are not yet supported
+// by DDC.
+String uriEncodeComponent(String str) {
+  // TODO: improve this
+
+  return str.replaceAll(' ', '%20');
+
+  // return Uri.encodeComponent(component);
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,12 +1,8 @@
 // Copyright (c) 2016, Devon Carew. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
-// TODO: This is a workaround for the fact that typed arrays are not yet supported
-// by DDC.
+// This is a workaround for the fact that typed arrays are not yet supported
+// by DDC (https://github.com/dart-lang/dev_compiler/issues/413).
 String uriEncodeComponent(String str) {
-  // TODO: improve this
-
   return str.replaceAll(' ', '%20');
-
-  // return Uri.encodeComponent(component);
 }


### PR DESCRIPTION
When compiled with DDC, atom commands events come in as the type `CustomEvent`. With dart2js, they come in as `JsObject`. We handle both cases, but are sad about it.
