### PR TITLE
improve our handling of situations where we don't have full env variables

### DIFF
--- a/lib/node/process.dart
+++ b/lib/node/process.dart
@@ -195,8 +195,8 @@ class MacShellWrangler {
   Map<String, String> _env;
 
   MacShellWrangler() {
-    _currentShell = execSync(r'echo $0');
-    _targetShell = execSync(r'echo $SHELL');
+    _currentShell = queryEnv('0');
+    _targetShell = queryEnv('SHELL');
 
     if (isNecessary) {
       String result;

--- a/lib/node/process.dart
+++ b/lib/node/process.dart
@@ -189,6 +189,15 @@ String queryEnv(String variable) {
 
 /// This class exists to help manage situations where Atom is running in an
 /// environment without a properly set up environment (env and PATH variables).
+///
+/// When Atom is launched from the Dock on macos, it is run in the borne shell
+/// (/bin/sh). A user's default shell on the mac is bash, so the borne shell
+/// will have none of the user's environment variables or path set up. Atom will
+/// not be able to locate or launch many user command-line applications. In
+/// order to fix this, we:
+/// - detect the current shell and the user's preferred shell
+/// - gather all the env variables from the preferred shell
+/// - when exec'ing a process, pass in the env variables discovered from the user's shell
 class MacShellWrangler {
   String _currentShell;
   String _targetShell;

--- a/lib/src/js.dart
+++ b/lib/src/js.dart
@@ -80,7 +80,7 @@ class JsDisposable extends ProxyHolder implements Disposable {
 }
 
 class Promise<T> extends ProxyHolder {
-  static _jsObjectFromFuture(Future future) {
+  static JsObject _jsObjectFromFuture(Future future) {
     // var promise = new Promise(function(resolve, reject) {
     //   // do a thing, possibly async, then…
     //


### PR DESCRIPTION
Improve our handling of situations where we don't have full env variables. Mac only:
- detect the current shell and the user's preferred shell
- gather all the env variables from the preferred shell
- when exec'ing a process, pass in the env variables discovered from the user's shell

@danrubel 
