### PR TITLE
cleanup warnings

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,2 +1,2 @@
 analyzer:
-  strong-mode: true
+#  strong-mode: true

--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -14,9 +14,6 @@ import 'src/js.dart';
 import 'src/utils.dart';
 import 'utils/disposable.dart';
 
-//TODO(danrubel) remove once references have been cleaned up
-export 'node/package.dart';
-
 final Logger _logger = new Logger('atom');
 
 /// The singleton instance of [Atom].

--- a/lib/atom_utils.dart
+++ b/lib/atom_utils.dart
@@ -31,19 +31,19 @@ Future<String> which(String execName, {bool isBatchScript: false}) {
       result = result.trim();
       if (result.contains('\n')) result = result.split('\n').first;
       return result;
-    }) as Future<String>;
+    });
   } else if (isWindows) {
     String ext = isBatchScript ? 'bat' : 'exe';
     return exec('where', ['${execName}.${ext}']).then((String result) {
       result = result.trim();
       if (result.contains('\n')) result = result.split('\n').first;
       return result;
-    }) as Future<String>;
+    });
   } else {
     return exec('which', [execName]).then((String result) {
       result = result.trim();
       if (result.contains('\n')) result = result.split('\n').first;
       return result;
-    }) as Future<String>;
+    });
   }
 }

--- a/lib/node/notification.dart
+++ b/lib/node/notification.dart
@@ -223,7 +223,7 @@ class ProcessNotifier {
         _helper.setSummary('Finished with exit code ${result}.');
       }
       return result;
-    }) as Future<int>;
+    });
   }
 }
 

--- a/lib/node/package.dart
+++ b/lib/node/package.dart
@@ -100,12 +100,11 @@ abstract class AtomPackage {
     String url = 'atom://${id}/package.json';
     return HttpRequest.getString(url).then((String str) {
       return JSON.decode(str) as Map<String, dynamic>;
-    }) as Future<Map<String, dynamic>>;
+    });
   }
 
   Future<String> getPackageVersion() {
-    return loadPackageJson().then((Map map) => map['version'])
-        as Future<String>;
+    return loadPackageJson().then((Map map) => map['version']);
   }
 
   /// Register a method for a service callback (`consumedServices`).

--- a/lib/node/process.dart
+++ b/lib/node/process.dart
@@ -44,7 +44,7 @@ Future<String> exec(String command, [List<String> args, Map<String, String> env]
   return runner.execSimple().then((ProcessResult result) {
     if (result.exit == 0) return result.stdout;
     throw result.exit;
-  }) as Future<String>;
+  });
 }
 
 /// Execute the given command synchronously and return the stdout. If the
@@ -117,7 +117,7 @@ class ProcessRunner {
 
     return execStreaming().then((code) {
       return new ProcessResult(code, stdout.toString(), stderr.toString());
-    }) as Future<ProcessResult>;
+    });
   }
 
   Future<int> execStreaming() {


### PR DESCRIPTION
This cleans up warnings in atom.dart, but the dartlang build, which consumes atom.dart, does not show these warnings. Should they be cleaned up? Or not?

@devoncarew 
