### PR TITLE
remove the TERM env var

### DIFF
--- a/lib/atom_utils.dart
+++ b/lib/atom_utils.dart
@@ -5,7 +5,7 @@
 library atom_utils;
 
 import 'dart:async';
-import 'dart:html' show CustomEvent, DivElement, Element, HttpRequest, Node, NodeTreeSanitizer;
+import 'dart:html' show Node, NodeTreeSanitizer;
 
 import 'package:atom/node/process.dart';
 import 'package:logging/logging.dart';

--- a/lib/node/command.dart
+++ b/lib/node/command.dart
@@ -2,7 +2,7 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html' show CustomEvent, Element, HttpRequest;
+import 'dart:html' show Element;
 
 import 'package:logging/logging.dart';
 

--- a/lib/node/package.dart
+++ b/lib/node/package.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert' show JSON;
-import 'dart:html' show CustomEvent, Element, HttpRequest;
+import 'dart:html' show HttpRequest;
 
 import '../src/js.dart';
 import '../utils/disposable.dart';

--- a/lib/node/process.dart
+++ b/lib/node/process.dart
@@ -220,7 +220,12 @@ class MacShellWrangler {
       for (String line in result.split('\n')) {
         int index = line.indexOf('=');
         if (index != -1) {
-          _env[line.substring(0, index)] = line.substring(index + 1);
+          String key = line.substring(0, index);
+          String value = line.substring(index + 1);
+
+          // Strip the `TERM` environment variable - when launching processes we
+          // do not support ansi codes.
+          if (key != 'TERM') _env[key] = value;
         }
       }
     }


### PR DESCRIPTION
- Strip the `TERM` environment variable when launching processes (we do not support ansi codes)
- remove some unused `show` imports

@danrubel 
