### PR TITLE
work around an issue starting atom from unix launchers

### DIFF
--- a/lib/atom_utils.dart
+++ b/lib/atom_utils.dart
@@ -24,15 +24,7 @@ ShellWrangler _shellWrangler;
 /// Note: on Windows, this assumes that we're looking for an `.exe` unless
 /// `isBatchScript` is specified.
 Future<String> which(String execName, {bool isBatchScript: false}) {
-  if (isMac) {
-    if (_shellWrangler == null) _shellWrangler = new ShellWrangler();
-
-    return exec('which', [execName], _shellWrangler.env).then((String result) {
-      result = result.trim();
-      if (result.contains('\n')) result = result.split('\n').first;
-      return result;
-    });
-  } else if (isWindows) {
+  if (isWindows) {
     String ext = isBatchScript ? 'bat' : 'exe';
     return exec('where', ['${execName}.${ext}']).then((String result) {
       result = result.trim();
@@ -40,6 +32,7 @@ Future<String> which(String execName, {bool isBatchScript: false}) {
       return result;
     });
   } else {
+    // posix - linux and mac
     if (_shellWrangler == null) _shellWrangler = new ShellWrangler();
 
     return exec('which', [execName], _shellWrangler.env).then((String result) {

--- a/lib/atom_utils.dart
+++ b/lib/atom_utils.dart
@@ -17,7 +17,7 @@ class TrustedHtmlTreeSanitizer implements NodeTreeSanitizer {
   void sanitizeTree(Node node) { }
 }
 
-MacShellWrangler _shellWrangler;
+ShellWrangler _shellWrangler;
 
 /// Look for the given executable; throw an error if we can't find it.
 ///
@@ -25,7 +25,7 @@ MacShellWrangler _shellWrangler;
 /// `isBatchScript` is specified.
 Future<String> which(String execName, {bool isBatchScript: false}) {
   if (isMac) {
-    if (_shellWrangler == null) _shellWrangler = new MacShellWrangler();
+    if (_shellWrangler == null) _shellWrangler = new ShellWrangler();
 
     return exec('which', [execName], _shellWrangler.env).then((String result) {
       result = result.trim();
@@ -40,7 +40,9 @@ Future<String> which(String execName, {bool isBatchScript: false}) {
       return result;
     });
   } else {
-    return exec('which', [execName]).then((String result) {
+    if (_shellWrangler == null) _shellWrangler = new ShellWrangler();
+
+    return exec('which', [execName], _shellWrangler.env).then((String result) {
       result = result.trim();
       if (result.contains('\n')) result = result.split('\n').first;
       return result;

--- a/lib/node/process.dart
+++ b/lib/node/process.dart
@@ -16,7 +16,7 @@ final Process process = new Process._();
 final bool isWindows = process.platform.startsWith('win');
 final bool isMac = process.platform == 'darwin';
 final bool isLinux = !isWindows && !isMac;
-bool get isPosix => !isWindows;
+final bool isPosix = !isWindows;
 
 final Logger _logger = new Logger('process');
 

--- a/lib/node/process.dart
+++ b/lib/node/process.dart
@@ -86,10 +86,8 @@ class ProcessRunner {
   factory ProcessRunner.underShell(String command, {
     List<String> args, String cwd, Map<String, String> env
   }) {
-    if (isPosix && _shellWrangler == null) {
-      if (_shellWrangler == null) {
-        _shellWrangler = new ShellWrangler();
-      }
+    if (isPosix) {
+      _shellWrangler ??= new ShellWrangler();
 
       if (_shellWrangler.isNecessary) {
         return new ProcessRunner(command, args: args, cwd: cwd, env: _shellWrangler.env);


### PR DESCRIPTION
Possible fix for https://github.com/flutter/flutter/issues/3531 - the paths aren't set up for atom when its started from the system launchers.

@danrubel, I don't have an easy way to test on a linux box - would you mind giving this a spin? W/o this patch, atom should fail to find adb or devices when started from the system launcher. W/ it, it should find devices. And this should still work when atom is started from the command line :)
